### PR TITLE
Quote strings used as env vars

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: axiom
 description: Axiom Private
 type: application
-version: 0.19.0
+version: 0.19.1
 appVersion: 1.19.0
 maintainers:
 - name: Axiom Inc.

--- a/templates/core.yaml
+++ b/templates/core.yaml
@@ -71,8 +71,8 @@ spec:
         - name: AXIOM_PUBLIC_URL
           value: {{ .Values.externalUrl }}
         {{- range .Values.core.extraEnvs }}
-        - name: {{ .name }}
-          value: {{ .value }}
+        - name: {{ quote .name }}
+          value: {{ quote .value }}
         {{- end }}
       {{- if .Values.registryAccessToken }}
       imagePullSecrets:

--- a/templates/db.yaml
+++ b/templates/db.yaml
@@ -90,8 +90,8 @@ spec:
               key: fallback-storage-uri
         {{- end }}
         {{- range .Values.db.extraEnvs }}
-        - name: {{ .name }}
-          value: {{ .value }}
+        - name: {{ quote .name }}
+          value: {{ quote .value }}
         {{- end }}
         volumeMounts:
         - name: data

--- a/templates/query.yaml
+++ b/templates/query.yaml
@@ -42,8 +42,8 @@ spec:
               name: axiom-secrets
               key: storage-uri
         {{- range .Values.queryFn.extraEnvs }}
-        - name: {{ .name }}
-          value: {{ .value }}
+        - name: {{ quote .name }}
+          value: {{ quote .value }}
         {{- end }}
       {{- if .Values.registryAccessToken }}
       imagePullSecrets:


### PR DESCRIPTION
Tried using the `extraEnvs` values but got errors such as
```
StatefulSet in version "v1" cannot be handled as a StatefulSet: v1.StatefulSet.Spec: v1.StatefulSetSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container │
│ .Env: []v1.EnvVar: v1.EnvVar.Value: ReadString: expects " or n, but found 5,
```
due to lack of quoting.
