### PR TITLE
Fix affinity configuration

### DIFF
--- a/templates/core.yaml
+++ b/templates/core.yaml
@@ -16,18 +16,6 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                  - key: app
-                    operator: In
-                    values:
-                    - axiom-core
-                topologyKey: "kubernetes.io/hostname"
       containers:
       - name: axiom-core-pod
         {{- if .Values.core.imageOverride }}

--- a/templates/db.yaml
+++ b/templates/db.yaml
@@ -18,18 +18,6 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                  - key: app
-                    operator: In
-                    values:
-                    - axiom-db
-                topologyKey: "kubernetes.io/hostname"
       containers:
       - name: axiomdb-pod
         {{- if .Values.db.imageOverride }}

--- a/values.yaml
+++ b/values.yaml
@@ -96,7 +96,18 @@ core:
   podAnnotations: {}
   nodeSelector: {}
   tolerations: []
-  affinity: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - axiom-core
+            topologyKey: "kubernetes.io/hostname"
   extraEnvs: [] # [{ name: AXIOM_XYZ, value: "xyz" }, ... ]
 
 # Settings for axiom-db
@@ -112,7 +123,18 @@ db:
   podAnnotations: {}
   nodeSelector: {}
   tolerations: []
-  affinity: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - axiom-db
+            topologyKey: "kubernetes.io/hostname"
   extraEnvs: [] # [{ name: AXIOM_XYZ, value: "xyz" }, ... ]
 
 # Settings for axiomdb-query-fn


### PR DESCRIPTION
If an affinity block is provided in the values, two affinity blocks are rendered which invalidates the manifest. This moves the default into the values while still allowing any additions/overrides.